### PR TITLE
DO-3791 [skip ci]

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,26 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-message: 'This PR is stale because it has been open for 7 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been inactive for 7 days since being marked as stale.'
+          stale-pr-label: 'stale'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          exempt-pr-labels: 'keep-open,work-in-progress,blocked'
+          exempt-draft-pr: false
+          exempt-all-pr-assignees: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically manages stale pull requests:

- **Marks PRs as stale** after 7 days of inactivity
- **Closes stale PRs** after an additional 7 days (14 days total)
- **Runs daily** at 1:30 AM UTC
- **Exempts PRs** with labels: `keep-open`, `work-in-progress`, `blocked`

This helps maintain repository hygiene by automatically cleaning up abandoned PRs while giving contributors adequate notice and opportunity to resume work.

The workflow only affects pull requests, not issues, and uses the standard `GITHUB_TOKEN` for authentication.

[_Created by Sourcegraph batch change `Kevmo92/stale-pr-gha-workflow`._](https://ncino.sourcegraphcloud.com/users/Kevmo92/batch-changes/stale-pr-gha-workflow)